### PR TITLE
Add type specifications for dialyzer

### DIFF
--- a/src/salt.erl
+++ b/src/salt.erl
@@ -46,85 +46,115 @@
 %%% Public-key cryptography.
 
 %% Public-key authenticated encryption.
+
+-type resp_box() :: badarg | binary().
+-type resp_box_open() :: badarg | forged_or_garbled | {ok, binary()}.
+-type resp_auth() :: badarg | forged_or_garbled | authenticated.
+-type resp_bool() :: equal | not_equal.
+
+-spec crypto_box_keypair() -> {binary(), binary()}.
 crypto_box_keypair() ->
     salt_server:make_box_keypair().
 
+-spec crypto_box(iodata(), binary(), binary(), binary()) -> resp_box().
 crypto_box(Plain_text, Nonce, Public_key, Secret_key) ->
     salt_nif:salt_box([crypto_box_zerobytes() | Plain_text], Nonce, Public_key, Secret_key).
 
+-spec crypto_box_open(iodata(), binary(), binary(), binary()) ->
+        badarg | forged_or_garbled | {ok, binary()}.
 crypto_box_open(Cipher_text, Nonce, Public_key, Secret_key) ->
     salt_nif:salt_box_open([crypto_box_boxzerobytes() | Cipher_text], Nonce, Public_key, Secret_key).
 
+-spec crypto_box_beforenm(binary(), binary()) -> resp_box().
 crypto_box_beforenm(Public_key, Secret_key) ->
     salt_nif:salt_box_beforenm(Public_key, Secret_key).
 
+-spec crypto_box_afternm(iodata(), binary(), binary()) -> resp_box().
 crypto_box_afternm(Plain_text, Nonce, Context) ->
     salt_nif:salt_box_afternm([crypto_box_zerobytes() | Plain_text], Nonce, Context).
 
+-spec crypto_box_open_afternm(iodata(), binary(), binary()) -> resp_box_open().
 crypto_box_open_afternm(Cipher_text, Nonce, Context) ->
     salt_nif:salt_box_open_afternm([crypto_box_boxzerobytes() | Cipher_text], Nonce, Context).
 
 %% Scalar multiplication. NB: Opaque representation of integers and group elements on fixed-length octet strings.
+-spec crypto_scalarmult(binary(), binary()) -> resp_box().
 crypto_scalarmult(Integer, Group_p) ->
     salt_nif:salt_scalarmult(Integer, Group_p).
 
+-spec crypto_scalarmult_base(binary()) -> resp_box().
 crypto_scalarmult_base(Integer) ->
     salt_nif:salt_scalarmult(Integer).
 
 %% Signatures.
+-spec crypto_sign_keypair() -> {binary(), binary()}.
 crypto_sign_keypair() ->
     salt_server:make_sign_keypair().
 
+-spec crypto_sign(iodata(), binary()) -> resp_box().
 crypto_sign(Message, Secret_key) ->
-    salt_nif:salt_sign(Message, Secret_key).
+    salt_nif:salt_sign([Message], Secret_key).
 
+-spec crypto_sign_open(iodata(), binary()) -> resp_box_open().
 crypto_sign_open(Signed_msg, Public_key) ->
-    salt_nif:salt_sign_open(Signed_msg, Public_key).
+    salt_nif:salt_sign_open([Signed_msg], Public_key).
 
 %%% Secret-key cryptography.
 
 %% Authenticated encryption.
+-spec crypto_secretbox(iodata(), binary(), binary()) -> resp_box().
 crypto_secretbox(Plain_text, Nonce, Secret_key) ->
     salt_nif:salt_secretbox([crypto_secretbox_zerobytes() | Plain_text], Nonce, Secret_key).
 
+-spec crypto_secretbox_open(iodata(), binary(), binary()) -> resp_box_open().
 crypto_secretbox_open(Cipher_text, Nonce, Secret_key) ->
     salt_nif:salt_secretbox_open([crypto_secretbox_boxzerobytes() | Cipher_text], Nonce, Secret_key).
 
 %% Encryption.
+-spec crypto_stream(pos_integer(), binary(), binary()) -> resp_box().
 crypto_stream(Byte_cnt, Nonce, Secret_key) ->
     salt_nif:salt_stream(Byte_cnt, Nonce, Secret_key).
 
+-spec crypto_stream_xor(binary(), binary(), binary()) -> resp_box().
 crypto_stream_xor(Plain_text, Nonce, Secret_key) ->
     salt_nif:salt_stream_xor(Plain_text, Nonce, Secret_key).
 
 %% Message authentication.
+-spec crypto_auth(iodata(), binary()) -> resp_box().
 crypto_auth(Message, Secret_key) ->
-    salt_nif:salt_auth(Message, Secret_key).
+    salt_nif:salt_auth([Message], Secret_key).
 
+-spec crypto_auth_verify(binary(), iodata(), binary()) -> resp_auth().
 crypto_auth_verify(Authenticator, Message, Secret_key) ->
-    salt_nif:salt_auth_verify(Authenticator, Message, Secret_key).
+    salt_nif:salt_auth_verify(Authenticator, [Message], Secret_key).
 
 %% Single-message authentication.
+-spec crypto_onetimeauth(iodata(), binary()) -> resp_auth().
 crypto_onetimeauth(Message, Secret_key) ->
-    salt_nif:salt_onetimeauth(Message, Secret_key).
+    salt_nif:salt_onetimeauth([Message], Secret_key).
 
+-spec crypto_onetimeauth_verify(binary(), iodata(), binary()) -> resp_auth().
 crypto_onetimeauth_verify(Authenticator, Message, Secret_key) ->
-    salt_nif:salt_onetimeauth_verify(Authenticator, Message, Secret_key).
+    salt_nif:salt_onetimeauth_verify(Authenticator, [Message], Secret_key).
 
 %%% Low-level functions.
 
 %% Hashing.
+-spec crypto_hash(iodata()) -> resp_box().
 crypto_hash(Message) ->
-    salt_nif:salt_hash(Message).
+    salt_nif:salt_hash([Message]).
 
 %% String comparison.
+-spec crypto_verify_16(binary(), binary()) -> resp_bool().
 crypto_verify_16(Bin_x, Bin_y) ->
     salt_nif:salt_verify_16(Bin_x, Bin_y).
 
+-spec crypto_verify_32(binary(), binary()) -> resp_bool().
 crypto_verify_32(Bin_x, Bin_y) ->
     salt_nif:salt_verify_32(Bin_x, Bin_y).
 
 %% Random number generator.
+-spec crypto_random_bytes(pos_integer()) -> binary().
 crypto_random_bytes(Cnt) ->
     salt_server:make_random_bytes(Cnt).
 

--- a/src/salt_nif.erl
+++ b/src/salt_nif.erl
@@ -51,73 +51,73 @@ load() ->
 %%% Exported from salt_nif.c.
 
 start() ->
-    error(salt_not_loaded).
+    erlang:nif_error(salt_not_loaded).
 
 salt_box_keypair(_, _, _) ->
-    error(salt_not_loaded).
+    erlang:nif_error(salt_not_loaded).
 
 salt_box(_, _, _, _) ->
-    error(salt_not_loaded).
+    erlang:nif_error(salt_not_loaded).
 
 salt_box_open(_, _, _, _) ->
-    error(salt_not_loaded).
+    erlang:nif_error(salt_not_loaded).
 
 salt_box_beforenm(_, _) ->
-    error(salt_not_loaded).
+    erlang:nif_error(salt_not_loaded).
 
 salt_box_afternm(_, _, _) ->
-    error(salt_not_loaded).
+    erlang:nif_error(salt_not_loaded).
 
 salt_box_open_afternm(_, _, _) ->
-    error(salt_not_loaded).
+    erlang:nif_error(salt_not_loaded).
 
 salt_scalarmult(_, _) ->
-    error(salt_not_loaded).
+    erlang:nif_error(salt_not_loaded).
 
 salt_scalarmult_base(_) ->
-    error(salt_not_loaded).
+    erlang:nif_error(salt_not_loaded).
 
 salt_sign_keypair(_, _, _) ->
-    error(salt_not_loaded).
+    erlang:nif_error(salt_not_loaded).
 
 salt_sign(_, _) ->
-    error(salt_not_loaded).
+    erlang:nif_error(salt_not_loaded).
 
 salt_sign_open(_, _) ->
-    error(salt_not_loaded).
+    erlang:nif_error(salt_not_loaded).
 
 salt_secretbox(_, _, _) ->
-    error(salt_not_loaded).
+    erlang:nif_error(salt_not_loaded).
 
 salt_secretbox_open(_, _, _) ->
-    error(salt_not_loaded).
+    erlang:nif_error(salt_not_loaded).
 
 salt_stream(_, _, _) ->
-    error(salt_not_loaded).
+    erlang:nif_error(salt_not_loaded).
 
 salt_stream_xor(_, _, _) ->
-    error(salt_not_loaded).
+    erlang:nif_error(salt_not_loaded).
 
 salt_auth(_, _) ->
-    error(salt_not_loaded).
+    erlang:nif_error(salt_not_loaded).
 
 salt_auth_verify(_, _, _) ->
-    error(salt_not_loaded).
+    erlang:nif_error(salt_not_loaded).
 
 salt_onetimeauth(_, _) ->
-    error(salt_not_loaded).
+    erlang:nif_error(salt_not_loaded).
 
 salt_onetimeauth_verify(_, _, _) ->
-    error(salt_not_loaded).
+    erlang:nif_error(salt_not_loaded).
 
 salt_hash(_) ->
-    error(salt_not_loaded).
+    erlang:nif_error(salt_not_loaded).
 
 salt_verify_16(_, _) ->
-    error(salt_not_loaded).
+    erlang:nif_error(salt_not_loaded).
 
 salt_verify_32(_, _) ->
-    error(salt_not_loaded).
+    erlang:nif_error(salt_not_loaded).
 
 salt_random_bytes(_, _, _, _) ->
-    error(salt_not_loaded).
+    erlang:nif_error(salt_not_loaded).

--- a/src/salt_server.erl
+++ b/src/salt_server.erl
@@ -49,7 +49,7 @@ make_sign_keypair() ->
     case gen_server:call(?MODULE, make_sign_keypair) of
 	{ok, Pk_sk} ->
 	    Pk_sk;
-	{error, Rsn} ->
+	{_error, Rsn} ->
 	    exit({salt, crypto_sign_keypair, Rsn})
     end.
 
@@ -68,7 +68,10 @@ make_random_bytes(Cnt) ->
 	 }).
 
 init([]) ->
-    ok = salt_nif:load(),
+    case salt_nif:load() of
+        ok -> ok;
+        {error, {reload, _}} -> ok
+    end,
     Pcb = salt_nif:start(),
     {ok, #state{pcb = Pcb}}.
 


### PR DESCRIPTION
I added typespecs to supress unnessasary dialyzer warnings (no returns).
- Typespecs are added
- error() is replaced by erlang:nif_error(),

In addition, I wraped some arguments with list to ensure types. For example, salt_nif:salt_sign() function parses first arguments as a iolist (via enif_inspect_iolist_as_binary() c api). Erlang iolist() does not include raw buffers, so I wrapped it with list.
