### PR TITLE
Allow clean compile and test on OS X Yosemite (Erlang 17.5). Find erl and rebar in PATH not hardcoded.

### DIFF
--- a/_build
+++ b/_build
@@ -1,6 +1,4 @@
 #!/bin/sh -ex
 
-export PATH="${HOME}/R16B01/bin/erl:${PATH}"
-
-../rebar.git/rebar clean
-../rebar.git/rebar compile
+rebar clean
+rebar compile

--- a/_run
+++ b/_run
@@ -3,7 +3,7 @@
 ### Not documented as such, but inhibits annoying crash dumps.
 export ERL_CRASH_DUMP=""
 
-${HOME}/R16B01/bin/erl -pa $(pwd)/ebin -boot start_sasl -noshell \
+erl -pa $(pwd)/ebin -boot start_sasl -noshell \
 	-eval 'c:c(salt_test).' \
 	-eval 'salt_test:all().' \
 	-eval 'init:stop().'

--- a/_shell
+++ b/_shell
@@ -3,5 +3,5 @@
 ### Not documented as such, but inhibits annoying crash dumps.
 export ERL_CRASH_DUMP=""
 
-${HOME}/R16B01/bin/erl -pa $(pwd) -pa $(pwd)/ebin -boot start_sasl \
+erl -pa $(pwd) -pa $(pwd)/ebin -boot start_sasl \
 	-eval 'application:start(salt).'

--- a/rebar.config.script
+++ b/rebar.config.script
@@ -9,7 +9,7 @@ Arch = erlang:system_info(system_architecture),
 lists:keymerge(1,
     lists:keysort(1, [
         {port_env, [{"DRV_CFLAGS", "$DRV_CFLAGS -Wall -Werror -I/usr/local/include/sodium"},
-		    {"DRV_LDFLAGS", "$DRV_LDFLAGS -L/usr/local/lib -Wl,-R/usr/local/lib -lsodium"}]},
+		    {"DRV_LDFLAGS", "$DRV_LDFLAGS -L/usr/local/lib -Wl -lsodium"}]},
         {port_specs, [{filename:join(["priv", Arch, "salt_nif.so"]), ["c_src/salt_nif.c"]}]},
         {pre_hooks, [{clean, "rm -fr ebin erl_crash.dump salt_test.beam c_src/salt_nif.o priv/" ++ Arch}]}
     ]),


### PR DESCRIPTION
Eliminates compile failure:

```
~/src/salt (master ✔)$ rebar compile
==> salt (compile)
Compiled src/salt_sup.erl
Compiled src/salt_server.erl
Compiled src/salt_nif.erl
Compiled src/salt_app.erl
Compiled src/salt.erl
Compiling c_src/salt_nif.c
ld: unknown option: -R/usr/local/lib
clang: error: linker command failed with exit code 1 (use -v to see invocation)
ERROR: sh(cc c_src/salt_nif.o $LDFLAGS -bundle -flat_namespace -undefined suppress  -L/usr/local/Cellar/erlang/17.5/lib/erlang/lib/erl_interface-3.7.20/lib -lerl_interface -lei -L/usr/local/lib -Wl,-R/usr/local/lib -lsodium -o priv/x86_64-apple-darwin14.1.0/salt_nif.so)
failed with return code 1 and the following output:
ld: unknown option: -R/usr/local/lib
clang: error: linker command failed with exit code 1 (use -v to see invocation)

ERROR: compile failed while processing /Users/glenn/src/salt: rebar_abort
```
